### PR TITLE
Fix CI build by updating feature associated with 'bench' feature

### DIFF
--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -124,7 +124,7 @@ def escape_char(c):
 
 def emit_bsearch_range_table(f):
     f.write("""
-fn bsearch_range_table(c: char, r: &'static [(char,char)]) -> bool {
+fn bsearch_range_table(c: char, r: &[(char,char)]) -> bool {
     use core::cmp::Ordering::{Equal, Less, Greater};
 
     r.binary_search_by(|&(lo,hi)| {
@@ -135,7 +135,7 @@ fn bsearch_range_table(c: char, r: &'static [(char,char)]) -> bool {
 }\n
 """)
 
-def emit_table(f, name, t_data, t_type = "&'static [(char, char)]", is_pub=True,
+def emit_table(f, name, t_data, t_type = "&[(char, char)]", is_pub=True,
         pfun=lambda x: "(%s,%s)" % (escape_char(x[0]), escape_char(x[1])), is_const=True):
     pub_string = "const"
     if not is_const:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
        html_favicon_url = "https://unicode-rs.github.io/unicode-rs_sm.png")]
 
 #![no_std]
-#![cfg_attr(feature = "bench", feature(test, unicode))]
+#![cfg_attr(feature = "bench", feature(test, rustc_private))]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -27,7 +27,7 @@ fn bsearch_range_table(c: char, r: &'static [(char,char)]) -> bool {
 }
 
 pub mod derived_property {
-    pub const XID_Continue_table: &'static [(char, char)] = &[
+    pub const XID_Continue_table: &[(char, char)] = &[
         ('\u{30}', '\u{39}'), ('\u{41}', '\u{5a}'), ('\u{5f}', '\u{5f}'), ('\u{61}', '\u{7a}'),
         ('\u{aa}', '\u{aa}'), ('\u{b5}', '\u{b5}'), ('\u{b7}', '\u{b7}'), ('\u{ba}', '\u{ba}'),
         ('\u{c0}', '\u{d6}'), ('\u{d8}', '\u{f6}'), ('\u{f8}', '\u{2c1}'), ('\u{2c6}', '\u{2d1}'),
@@ -241,7 +241,7 @@ pub mod derived_property {
         super::bsearch_range_table(c, XID_Continue_table)
     }
 
-    pub const XID_Start_table: &'static [(char, char)] = &[
+    pub const XID_Start_table: &[(char, char)] = &[
         ('\u{41}', '\u{5a}'), ('\u{61}', '\u{7a}'), ('\u{aa}', '\u{aa}'), ('\u{b5}', '\u{b5}'),
         ('\u{ba}', '\u{ba}'), ('\u{c0}', '\u{d6}'), ('\u{d8}', '\u{f6}'), ('\u{f8}', '\u{2c1}'),
         ('\u{2c6}', '\u{2d1}'), ('\u{2e0}', '\u{2e4}'), ('\u{2ec}', '\u{2ec}'), ('\u{2ee}',

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,8 +15,6 @@ use test::Bencher;
 #[cfg(feature = "bench")]
 use std::prelude::v1::*;
 
-use super::UnicodeXID;
-
 #[cfg(feature = "bench")]
 #[bench]
 fn cargo_is_xid_start(b: &mut Bencher) {
@@ -24,7 +22,7 @@ fn cargo_is_xid_start(b: &mut Bencher) {
 
     b.bytes = string.len() as u64;
     b.iter(|| {
-        string.chars().all(UnicodeXID::is_xid_start)
+        string.chars().all(super::UnicodeXID::is_xid_start)
     });
 }
 
@@ -46,7 +44,7 @@ fn cargo_xid_continue(b: &mut Bencher) {
 
     b.bytes = string.len() as u64;
     b.iter(|| {
-        string.chars().all(UnicodeXID::is_xid_continue)
+        string.chars().all(super::UnicodeXID::is_xid_continue)
     });
 }
 
@@ -69,7 +67,7 @@ fn test_is_xid_start() {
     ];
 
     for ch in &chars {
-        assert!(UnicodeXID::is_xid_start(*ch), "{}", ch);
+        assert!(super::UnicodeXID::is_xid_start(*ch), "{}", ch);
     }
 }
 
@@ -83,7 +81,7 @@ fn test_is_not_xid_start() {
     ];
 
     for ch in &chars {
-        assert!(!UnicodeXID::is_xid_start(*ch), "{}", ch);
+        assert!(!super::UnicodeXID::is_xid_start(*ch), "{}", ch);
     }
 }
 
@@ -95,7 +93,7 @@ fn test_is_xid_continue() {
     ];
 
     for ch in &chars {
-        assert!(UnicodeXID::is_xid_continue(*ch), "{}", ch);
+        assert!(super::UnicodeXID::is_xid_continue(*ch), "{}", ch);
     }
 }
 
@@ -108,6 +106,6 @@ fn test_is_not_xid_continue() {
     ];
 
     for &ch in &chars {
-        assert!(!UnicodeXID::is_xid_continue(ch), "{}", ch);
+        assert!(!super::UnicodeXID::is_xid_continue(ch), "{}", ch);
     }
 }


### PR DESCRIPTION
Also correct all cargo and clippy warnings, including an effective disambiguation between crate and stdlib supplied methods.

This crate is in the top 20 most downloaded crates, it probably ought to be building on CI correctly.

@SimonSapin 

Will update https://github.com/unicode-rs/unicode-xid/pull/9 after this (or related/subsequent fixes) land.