### PR TITLE
Upgrades the unsafe_code lint from deny to forbid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@
 //! unicode-xid = "0.0.4"
 //! ```
 
-#![deny(missing_docs, unsafe_code)]
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
 #![doc(html_logo_url = "https://unicode-rs.github.io/unicode-rs_sm.png",
        html_favicon_url = "https://unicode-rs.github.io/unicode-rs_sm.png")]
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,6 +16,9 @@ use test::Bencher;
 use std::prelude::v1::*;
 
 #[cfg(feature = "bench")]
+use UnicodeXID;
+
+#[cfg(feature = "bench")]
 #[bench]
 fn cargo_is_xid_start(b: &mut Bencher) {
     let string = iter::repeat('a').take(4096).collect::<String>();


### PR DESCRIPTION
This simply avoids the possibility of overriding the lint rule later in
the process. It also helps for tool usage, such as cargo geiger, where
it will now show the library at a higher safety level.