### PR TITLE
Speed up `bsearch_range_table`.

### DIFF
--- a/src/tables.rs
+++ b/src/tables.rs
@@ -20,9 +20,14 @@ fn bsearch_range_table(c: char, r: &[(char,char)]) -> bool {
     use core::cmp::Ordering::{Equal, Less, Greater};
 
     r.binary_search_by(|&(lo,hi)| {
-        if lo <= c && c <= hi { Equal }
+        // Because ASCII ranges are at the start of the tables, a search for an
+        // ASCII char will involve more `Greater` results (i.e. the `(lo,hi)`
+        // table entry is greater than `c`) than `Less` results. And given that
+        // ASCII chars are so common, it makes sense to favor them. Therefore,
+        // the `Greater` case is tested for before the `Less` case.
+        if lo > c { Greater }
         else if hi < c { Less }
-        else { Greater }
+        else { Equal }
     }).is_ok()
 }
 
@@ -446,6 +451,5 @@ pub mod derived_property {
     pub fn XID_Start(c: char) -> bool {
         super::bsearch_range_table(c, XID_Start_table)
     }
-
 }
 


### PR DESCRIPTION
The comparison function used for the binary search is sub-optimal,
because it looks for an `Equal` result first, even though that is the
least common result (happening 0 or 1 times per search).

This commit changes the comparison function to look for `Equals` last.
As a result, the number of tests executed within the comparison function
is reduced:
- On a `Greater` result: 2 tests --> 1 test
- On a `Less` result: 3 tests --> 2 tests
- On an `Equals` result (next most common): 2 tests --> 2 tests