### PR TITLE
Add ASCII fast path from rust-lang

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,19 @@ pub trait UnicodeXID {
 impl UnicodeXID for char {
     #[inline]
     fn is_xid_start(self) -> bool {
-        derived_property::XID_Start(self)
+        // Fast-path for ascii idents
+        ('a' <= self && self <= 'z')
+            || ('A' <= self && self <= 'Z')
+            || (self > '\x7f' && derived_property::XID_Start(self))
     }
 
     #[inline]
     fn is_xid_continue(self) -> bool {
-        derived_property::XID_Continue(self)
+        // Fast-path for ascii idents
+        ('a' <= self && self <= 'z')
+            || ('A' <= self && self <= 'Z')
+            || ('0' <= self && self <= '9')
+            || self == '_'
+            || (self > '\x7f' && derived_property::XID_Continue(self))
     }
 }


### PR DESCRIPTION
See rust-lang/rust's `src/librustc_lexer/src/lib.rs`

Idea came from #13