### PR TITLE
Declare minimum Rust version in Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ or XID_Continue properties according to
 Unicode Standard Annex #31.
 """
 exclude = ["/.github/**", "/scripts/*"]
+rust-version = "1.17"
 
 [features]
 default = []


### PR DESCRIPTION
See https://doc.rust-lang.org/nightly/cargo/reference/manifest.html#the-rust-version-field.

The first Cargo version that enforces the specified rustc version is 1.56, but having an accurate value is still valuable for other tooling, e.g. a third party Cargo subcommand to automatically update to package versions compatible with a particular compiler.