### PR TITLE
Make the tables `static`.

### DIFF
--- a/src/tables.rs
+++ b/src/tables.rs
@@ -37,7 +37,7 @@ fn bsearch_range_table(c: char, r: &[(char, char)]) -> bool {
 }
 
 pub mod derived_property {
-    pub const XID_Continue_table: &[(char, char)] = &[
+    static XID_Continue_table: &[(char, char)] = &[
         ('\u{30}', '\u{39}'),
         ('\u{41}', '\u{5a}'),
         ('\u{5f}', '\u{5f}'),
@@ -807,7 +807,7 @@ pub mod derived_property {
         super::bsearch_range_table(c, XID_Continue_table)
     }
 
-    pub const XID_Start_table: &[(char, char)] = &[
+    static XID_Start_table: &[(char, char)] = &[
         ('\u{41}', '\u{5a}'),
         ('\u{61}', '\u{7a}'),
         ('\u{aa}', '\u{aa}'),


### PR DESCRIPTION
Because it reduces the size of `.rlib` and `.rmeta` files by about 40KB.

I tested this on Linux with a tiny program that uses `unicode-xid`, which looks
like this:
```
use unicode_xid::UnicodeXID;
fn main() {
    println!(
	"{} {}",
	UnicodeXID::is_xid_start('\u{aabb}'),
	UnicodeXID::is_xid_continue('\u{aabb}')
    );
}
```

Here are the artifact sizes.
```
// debug artifacts w/pub const
  249374  libunicode_xid-75c27e72601d21ef.rlib
  193130  libunicode_xid-75c27e72601d21ef.rmeta
     542  unicode_xid-75c27e72601d21ef.d
 3780856  xid_user-75e09ca22117d2ec
     177  xid_user-75e09ca22117d2ec.d

// debug artifacts w/static
  204790  libunicode_xid-75c27e72601d21ef.rlib
  147433  libunicode_xid-75c27e72601d21ef.rmeta
     542  unicode_xid-75c27e72601d21ef.d
 3781592  xid_user-75e09ca22117d2ec
     177  xid_user-75e09ca22117d2ec.d

// release artifacts w/pub const
  209082  libunicode_xid-fc6c941385d516f3.rlib
  193860  libunicode_xid-fc6c941385d516f3.rmeta
     548  unicode_xid-fc6c941385d516f3.d
 3750768  xid_user-8544a1e3e820f27e
     181  xid_user-8544a1e3e820f27e.d

// release artifacts w/static
  163386  libunicode_xid-fc6c941385d516f3.rlib
  148164  libunicode_xid-fc6c941385d516f3.rmeta
     548  unicode_xid-fc6c941385d516f3.d
 3750768  xid_user-8544a1e3e820f27e
     181  xid_user-8544a1e3e820f27e.d

```
Effect on compile times is minimal, well within the noise:
```
// debug timings w/pub const
Benchmark 1: cargo build
  Time (mean ± σ):     865.9 ms ±  42.2 ms    [User: 773.5 ms, System: 283.9 ms]
  Range (min … max):   787.7 ms … 933.0 ms    10 runs

// debug timings w/static
Benchmark 1: cargo build
  Time (mean ± σ):     873.0 ms ±  34.7 ms    [User: 794.4 ms, System: 266.7 ms]
  Range (min … max):   821.6 ms … 923.0 ms    10 runs

// release timings w/pub const
Benchmark 1: cargo build --release
  Time (mean ± σ):     882.2 ms ±  49.4 ms    [User: 757.3 ms, System: 274.6 ms]
  Range (min … max):   793.2 ms … 946.5 ms    10 runs

// release timings w/static
Benchmark 1: cargo build --release
  Time (mean ± σ):     883.3 ms ±  63.1 ms    [User: 767.9 ms, System: 267.4 ms]
  Range (min … max):   785.7 ms … 970.9 ms    10 runs
```

Overall, it seems worth doing due to the disk space savings, because
`unicode-xid` is such a widely used crates (being used by `proc-macro2` and
`syn`).