### PR TITLE
Preserve static gains

### DIFF
--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -146,7 +146,7 @@ def emit_table(f, name, t_data, t_type = "&[(char, char)]", is_pub=True,
     if not is_const:
         pub_string = "let"
     if is_pub:
-        pub_string = "pub " + pub_string
+        pub_string = "static"
     f.write("    %s %s: %s = &[\n" % (pub_string, name, t_type))
     data = ""
     first = True


### PR DESCRIPTION
I saw that the latest merged https://github.com/unicode-rs/unicode-xid/pull/29 PR provides some gains for file size, which the generator script would override. This PR can help avoid such a situation. I think downstream projects can benefit from the size gain once the crate update is released!