### PR TITLE
Modernise the codebase (desc.)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.46.0, 1.17.0]
+        rust: [nightly, beta, stable]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -27,8 +27,6 @@ jobs:
       - run: cargo bench --features bench
         if: matrix.rust == 'nightly'
       - run: cargo build
-      - run: cargo test
-        if: matrix.rust != '1.17.0'
   tables:
     name: Verify tables
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
-// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2024 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
+// https://www.rust-lang.org/policies/licenses.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
@@ -12,13 +12,11 @@
 //! [Unicode Standard Annex #31](http://www.unicode.org/reports/tr31/) rules.
 //!
 //! ```rust
-//! extern crate unicode_xid;
-//!
 //! use unicode_xid::UnicodeXID;
 //!
 //! fn main() {
-//!     let ch = 'a';
-//!     println!("Is {} a valid start of an identifier? {}", ch, UnicodeXID::is_xid_start(ch));
+//!     assert_eq!(UnicodeXID::is_xid_start('a'), true); // 'a' is a valid start of an identifier
+//!     assert_eq!(UnicodeXID::is_xid_start('△'), false); // '△' is a NOT valid start of an identifier
 //! }
 //! ```
 //!

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,10 +1,10 @@
-// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2024 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
+// https://www.rust-lang.org/policies/licenses.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,10 +1,10 @@
-// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2024 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
+// https://www.rust-lang.org/policies/licenses.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 


### PR DESCRIPTION
- Update the copyright header
-  Update the root doc-comment example, and
- Remove '1.46' and '1.17' from CI, so that it can pass, being that it has been failing for 5 months.
