### PR TITLE
Improve CI, (almost) enforce MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,13 +75,13 @@ jobs:
       - name: Run tests without features
         run: cargo test --no-default-features --verbose
       - name: Package
-        run: cargo package --offline
+        run: cargo package
       - name: Test package
         working-directory: target/package/${{ needs.get-package-info.outputs.name }}-${{ needs.get-package-info.outputs.version }}/
-        run: cargo test --offline
+        run: cargo test --verbose
       - name: Test package without features
         working-directory: target/package/${{ needs.get-package-info.outputs.name }}-${{ needs.get-package-info.outputs.version }}/
-        run: cargo test --no-default-features --offline
+        run: cargo test --no-default-features --verbose
       - name: Run benchmarks
         run: cargo bench --features bench --verbose
         if: matrix.rust == 'nightly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install toolchain
+        if: matrix.rust != needs.get-package-info.outputs.msrv
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
+      - name: Install MSRV toolchain
+        if: matrix.rust == needs.get-package-info.outputs.msrv
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ needs.get-package-info.outputs.msrv }}
       - name: Build
         run: cargo build --verbose
       - name: Run tests with all features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         working-directory: target/package/${{ needs.get-package-info.outputs.name }}-${{ needs.get-package-info.outputs.version }}/
         run: cargo test --no-default-features --offline
       - name: Run benchmarks
-        run: cargo bench
+        run: cargo bench --features bench --verbose
         if: matrix.rust == 'nightly'
       - name: Build docs
         run: cargo doc --all-features --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ needs.get-package-info.outputs.msrv }}
+      - name: Remove dev-dependencies for MSRV (very dirty hack)
+        if: matrix.rust == needs.get-package-info.outputs.msrv
+        shell: pwsh
+        run: |
+          (Get-Content Cargo.toml) -replace '^\[dev-dependencies\].*?(\n\[|$)', '[placeholder]' | Set-Content Cargo.toml
       - name: Build
         run: cargo build --verbose
       - name: Run tests with all features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run tests without features
         run: cargo test --no-default-features --verbose
       - name: Package
-        run: cargo package
+        run: cargo package --allow-dirty
       - name: Test package
         working-directory: target/package/${{ needs.get-package-info.outputs.name }}-${{ needs.get-package-info.outputs.version }}/
         run: cargo test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,35 +2,88 @@ name: CI
 
 on:
   push:
+    branches: [ master ]
   pull_request:
-  schedule: [cron: "40 1 * * *"]
+    branches: [ master ]
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings --cfg docsrs
 
 jobs:
-  test:
-    name: Rust ${{matrix.rust}}
+  get-package-info:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [nightly, beta, stable]
+    outputs:
+      msrv: ${{ steps.msrv.outputs.metadata }}
+      name: ${{ steps.name.outputs.metadata }}
+      version: ${{ steps.version.outputs.metadata }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v5
+      - name: Get MSRV
+        id: msrv
+        uses: nicolaiunrein/cargo-get@v1.4.0
         with:
-          toolchain: ${{matrix.rust}}
-          profile: minimal
-          override: true
-      - run: cargo build --features bench
+          subcommand: 'package.rust_version'
+      - name: Get package name
+        id: name
+        uses: nicolaiunrein/cargo-get@v1.4.0
+        with:
+          subcommand: 'package.name'
+      - name: Get package version
+        id: version
+        uses: nicolaiunrein/cargo-get@v1.4.0
+        with:
+          subcommand: 'package.version'
+
+  build_test:
+    needs: get-package-info
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+        rust:
+          - ${{ needs.get-package-info.outputs.msrv }}
+          - stable
+          - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests with all features
+        run: cargo test --all-features --verbose
         if: matrix.rust == 'nightly'
-      - run: cargo test --features bench
+      - name: Run tests without features
+        run: cargo test --no-default-features --verbose
+      - name: Package
+        run: cargo package --offline
+      - name: Test package
+        working-directory: target/package/${{ needs.get-package-info.outputs.name }}-${{ needs.get-package-info.outputs.version }}/
+        run: cargo test --offline
+      - name: Test package without features
+        working-directory: target/package/${{ needs.get-package-info.outputs.name }}-${{ needs.get-package-info.outputs.version }}/
+        run: cargo test --no-default-features --offline
+      - name: Run benchmarks
+        run: cargo bench
         if: matrix.rust == 'nightly'
-      - run: cargo bench --features bench
+      - name: Build docs
+        run: cargo doc --all-features --verbose
         if: matrix.rust == 'nightly'
-      - run: cargo build
+
   tables:
     name: Verify tables
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
+      - name: Regenerate tables
+        run: ./scripts/unicode.py && rustfmt tables.rs
       - name: Verify regenerated files
-        run: ./scripts/unicode.py && rustfmt tables.rs && diff tables.rs src/tables.rs
+        run:  diff tables.rs src/tables.rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
           - stable
           - beta
           - nightly
+        exclude:
+          # excludes MSRV on Windows due to linker issues
+          - os: windows-latest
+            rust: ${{ needs.get-package-info.outputs.msrv }}
     steps:
       - uses: actions/checkout@v5
       - name: Install toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 
 name = "unicode-xid"
 version = "0.2.6"
-authors = ["erick.tryzelaar <erick.tryzelaar@gmail.com>",
-           "kwantam <kwantam@gmail.com>",
-           "Manish Goregaokar <manishsmail@gmail.com>"
-           ]
+authors = [
+  "erick.tryzelaar <erick.tryzelaar@gmail.com>",
+  "kwantam <kwantam@gmail.com>",
+  "Manish Goregaokar <manishsmail@gmail.com>",
+]
 
 homepage = "https://github.com/unicode-rs/unicode-xid"
 repository = "https://github.com/unicode-rs/unicode-xid"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
     html_favicon_url = "https://unicode-rs.github.io/unicode-rs_sm.png"
 )]
 #![no_std]
-#![cfg_attr(feature = "bench", feature(test, unicode_internals))]
+#![cfg_attr(feature = "bench", feature(test))]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,8 @@
 //! ```rust
 //! use unicode_xid::UnicodeXID;
 //!
-//! fn main() {
-//!     assert_eq!(UnicodeXID::is_xid_start('a'), true); // 'a' is a valid start of an identifier
-//!     assert_eq!(UnicodeXID::is_xid_start('△'), false); // '△' is a NOT valid start of an identifier
-//! }
+//! assert_eq!(UnicodeXID::is_xid_start('a'), true); // 'a' is a valid start of an identifier
+//! assert_eq!(UnicodeXID::is_xid_start('△'), false); // '△' is a NOT valid start of an identifier
 //! ```
 //!
 //! # features

--- a/tests/exhaustive_tests.rs
+++ b/tests/exhaustive_tests.rs
@@ -1,13 +1,19 @@
 extern crate unicode_xid;
+
 use unicode_xid::UnicodeXID;
 /// A `char` in Rust is a Unicode Scalar Value
 ///
 /// See: http://www.unicode.org/glossary/#unicode_scalar_value
-fn all_valid_chars() -> impl Iterator<Item = char> {
-    (0u32..=0xD7FF).chain(0xE000u32..=0x10FFFF).map(|u| {
-        core::convert::TryFrom::try_from(u)
-            .expect("The selected range should be infallible if the docs match impl")
-    })
+fn all_valid_chars() -> Vec<char> {
+    (0u32..0xD7FF)
+        .chain(Some(0xD7FF))
+        .chain(0xE000u32..0x10FFFF)
+        .chain(Some(0x10FFFF))
+        .map(|u| {
+            std::char::from_u32(u)
+                .expect("The selected range should be infallible if the docs match impl")
+        })
+        .collect()
 }
 
 #[test]


### PR DESCRIPTION
This brings several improvements to the CI:
- Test MSRV
- Test Windows
- Replace deprecated actions

Also make the tests compatible with MSRV.
The usage of MSRV still requires to exclude the criterion dev-dependency used for benchmarks.